### PR TITLE
allow deactivation of elastic repo configuration through var

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -29,6 +29,8 @@ logstash_apt_repo_string: "{{ elastic_apt_repo_string | default('deb https://art
 # Name of the service
 logstash_service: logstash
 
+# installs and configures elastic repo if true
+logstash_configure_package_repo: true
 
 # Path to the main config file
 logstash_config_file: /etc/logstash/logstash.yml

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -8,36 +8,39 @@
   tags:
     - logstash_assert
 
-- name: Create Logstash YUM repo file
-  yum_repository:
-    name: elastic
-    description: Elastic YUM repo
-    baseurl: "{{ logstash_yum_repo_url }}"
-    gpgkey: "{{ logstash_yum_repo_key }}"
-    params: "{{ logstash_yum_repo_params }}"
-  when: >
-    ansible_os_family == 'RedHat'
-  tags:
-    - logstash_pkg
-    - logstash_yumrepo
+- name: configure package repository
+  block:
+    - name: Create Logstash YUM repo file
+      yum_repository:
+        name: elastic
+        description: Elastic YUM repo
+        baseurl: "{{ logstash_yum_repo_url }}"
+        gpgkey: "{{ logstash_yum_repo_key }}"
+        params: "{{ logstash_yum_repo_params }}"
+      when: >
+        ansible_os_family == 'RedHat'
+      tags:
+        - logstash_pkg
+        - logstash_yumrepo
 
-- name: Install Logstash GPG key
-  apt_key:
-    url: "{{ logstash_apt_repo_key }}"
-  when: >
-    ansible_os_family == 'Debian'
-  tags:
-    - logstash_pkg
-    - logstash_aptrepo
+    - name: Install Logstash GPG key
+      apt_key:
+        url: "{{ logstash_apt_repo_key }}"
+      when: >
+        ansible_os_family == 'Debian'
+      tags:
+        - logstash_pkg
+        - logstash_aptrepo
 
-- name: Create Logstash APT repo file
-  apt_repository:
-    repo: "{{ logstash_apt_repo_string }}"
-  when: >
-    ansible_os_family == 'Debian'
-  tags:
-    - logstash_pkg
-    - logstash_aptrepo
+    - name: Create Logstash APT repo file
+      apt_repository:
+        repo: "{{ logstash_apt_repo_string }}"
+      when: >
+        ansible_os_family == 'Debian'
+      tags:
+        - logstash_pkg
+        - logstash_aptrepo
+  when: logstash_configure_package_repo
 
 - name: Install additional Logstash packages
   package:


### PR DESCRIPTION
Dear Sir,

I added the option disable the installation of the external elastic repo through a variable.
Even though you added nice tags for this, however those are only usable with the command line and not manageable in a playbook.

Your tasks remain unchanged, I only put them in a block with the condition for `logstash_configure_package_repo`
Which is set to true in the default. So the behavior of your role stays unchanged.

**Additional Info:**
Our Servers are firewalled and we manage our own repos.
Because I'm not the only one executing the playbook I have to make it usable without extra command line parameters which someone else might forget to be failsafe.

I believe others might need this option too.


Yours faithfully,
coreaut